### PR TITLE
chore: add security stuff to config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:best-practices"],
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "labels": ["security"]
+  },
   "schedule": [
     "after 6pm every weekday",
     "every weekend",


### PR DESCRIPTION
# Context

`config:best-practices` enables `vulnerabilityAlerts` by default but doesn't turn on the OSV.dev source or surface security PRs visually. Pulled current Renovate docs via Context7 to confirm what the preset covers and what's still worth adding on top.

# Changes Made

- `osvVulnerabilityAlerts: true` — extra vuln coverage for direct deps from OSV.dev (Renovate's recommended best practice; defaults to false)
- `vulnerabilityAlerts.labels: ["security"]` — auto-labels security PRs so they stand out from regular bumps
- No automerge on vuln PRs — Renovate docs explicitly warn against it (false-positive alerts can land bad code)

# Testing Notes

- No code change, config-only — CI runs lint/test/typecheck but nothing here exercises Renovate
- Validation happens on next Renovate run: confirm any future security PRs land with the `security` label, and check the dependency dashboard issue for the "Pending Vulnerability Alerts" section
- Open `uuid` alert (transitive dev dep, GHSA-w5hq-g745-h8pq) is the live test case — if it doesn't surface after this lands, the fix may not be in semver range and would need a `pnpm.overrides` entry