### PR TITLE
ci: migrate runners to arm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   checks:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     steps:
       - name: Checkout Code

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   resolve-tag:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 2
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
@@ -52,7 +52,7 @@ jobs:
       github.event_name == 'release' ||
       inputs.stores == 'chrome' ||
       inputs.stores == 'all'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 5
     environment: chrome-store
     concurrency:
@@ -108,7 +108,7 @@ jobs:
       github.event_name == 'release' ||
       inputs.stores == 'firefox' ||
       inputs.stores == 'all'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 5
     environment: firefox-store
     concurrency:
@@ -172,7 +172,7 @@ jobs:
       github.event_name == 'release' ||
       inputs.stores == 'edge' ||
       inputs.stores == 'all'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 5
     environment: edge-store
     concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     steps:
       - name: Checkout code


### PR DESCRIPTION
# Summary

update `runs-on:` to `ubuntu-24.04-arm` across all runners.