### PR TITLE
feat(env-filter): add env search to the deployments sidebar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,3 +51,5 @@ WXT browser extension (Svelte + TypeScript) that cleans up GitHub UI annoyances.
 
 - `storage` from WXT is an auto-import global — don't add `import { storage } from "wxt/storage"` in `src/lib/` files
 - Generated `.wxt/tsconfig.json` enables `noUncheckedIndexedAccess` — array/record indexing yields `T | undefined`, narrow or use optional chaining
+- GitHub's newer pages (e.g. `/deployments`) are React apps — never mutate React-owned DOM (workflow-filter's `replaceChildren` approach only works on server-rendered pages like `/actions`). Mount in a sibling container and hide/show via CSS instead; see `env-filter`
+- React pages use hashed CSS-module classes — match on the stable prefix with `[class*="..."]` selectors, never the full class name

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="public/icon/128.png" width="128" height="128" alt="Grody GitHub" />
 </p>
 
-Filter your long list of workflows in GitHub! Know about GitHub incidents before you start blaming your code! And more to come.
+Filter your long lists of workflows and deployment environments in GitHub! Know about GitHub incidents before you start blaming your code! And more to come.
 
 <p align="center">
   <a href="https://chromewebstore.google.com/detail/pbghkjaknoiilominkjgmfjeoobkhfkn"><img src="https://badgen.net/chrome-web-store/v/pbghkjaknoiilominkjgmfjeoobkhfkn?icon=chrome&color=blue" alt="Chrome Web Store" /></a>
@@ -15,7 +15,7 @@ Filter your long list of workflows in GitHub! Know about GitHub incidents before
 
 ## What is this
 
-GitHub's UI is fine. Until it isn't. If you've ever scrolled through a sidebar of 80 workflows trying to find the one you need, you know the feeling.
+GitHub's UI is fine. Until it isn't. If you've ever scrolled through a sidebar of 80 workflows — or a deployments page with 100+ environments — trying to find the one you need, you know the feeling.
 
 Grody GitHub is a Chrome extension that bolts small, targeted fixes onto GitHub's interface. One feature at a time. No bloat.
 
@@ -31,6 +31,14 @@ Adds a search box to the Actions sidebar so you can actually find your workflows
 - Caches the workflow list for 24 hours so it's snappy after first load
 - Works with dark theme
 - Handles repos with hundreds of workflows without breaking a sweat
+
+### Environment Sidebar Filter
+
+Same idea, but for the deployments page. Repos with dozens of environments get a search box above the environments sidebar.
+
+- Real-time search on environment name — covers everything hidden behind "Show more environments"
+- Caches the environment list for 24 hours
+- Only shows up when the list is actually truncated
 
 ## Optional Features
 
@@ -78,8 +86,8 @@ Then in Chrome:
 ```bash
 pnpm dev            # Dev server with hot reload (Chrome)
 pnpm dev:firefox    # Dev server (Firefox)
-pnpm format         # Biome formatter
 pnpm lint           # Biome check (format + lint)
+pnpm lint:fix       # Biome check with autofix
 pnpm test           # Run tests
 pnpm check          # Svelte type checking
 ```

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -1,4 +1,4 @@
-import { getWorkflows } from "@/lib/github-api";
+import { getEnvironments, getWorkflows } from "@/lib/github-api";
 import {
   collapsedStorage,
   enabledStorage,
@@ -46,6 +46,10 @@ export default defineBackground(() => {
     (message: ExtensionMessage, _sender, sendResponse) => {
       if (message.type === "GET_WORKFLOWS") {
         getWorkflows(message.owner, message.repo).then(sendResponse);
+        return true;
+      }
+      if (message.type === "GET_ENVIRONMENTS") {
+        getEnvironments(message.owner, message.repo).then(sendResponse);
         return true;
       }
     },

--- a/src/entrypoints/grody.content/features/env-filter/EnvFilter.svelte
+++ b/src/entrypoints/grody.content/features/env-filter/EnvFilter.svelte
@@ -1,0 +1,197 @@
+<script lang="ts">
+import { onMount } from "svelte";
+import { requestEnvironments } from "@/lib/github-api";
+import type { Environment, EnvironmentResult } from "@/lib/types";
+
+let {
+  owner,
+  repo,
+  container,
+}: { owner: string; repo: string; container: HTMLElement } = $props();
+
+let query = $state("");
+let environments: Environment[] = $state([]);
+let loaded = $state(false);
+let hint = $state<string | null>(null);
+let inputEl: HTMLInputElement | undefined = $state();
+
+const filtering = $derived(query.trim().length > 0);
+
+const filtered = $derived.by(() => {
+  const terms = query.toLowerCase().split(/\s+/).filter(Boolean);
+  if (terms.length === 0) return [];
+  return environments.filter((env) =>
+    terms.every((term) => env.name.toLowerCase().includes(term)),
+  );
+});
+
+// React owns the nav we hide; the attribute lives on our container so the
+// injected stylesheet rule never has to touch React-managed elements.
+$effect(() => {
+  container.toggleAttribute("data-filtering", filtering);
+});
+
+function handleClear() {
+  query = "";
+  inputEl?.focus();
+}
+
+onMount(() => {
+  requestEnvironments(owner, repo)
+    .then((result: EnvironmentResult) => {
+      if (!result.ok) {
+        if (result.reason === "rate-limited") {
+          hint = "Rate limited — add a token in extension options";
+        } else if (result.reason === "auth-required") {
+          hint = "Private repo — add a token in extension options";
+        }
+        return;
+      }
+      if (result.environments.length === 0) return;
+      environments = result.environments;
+      loaded = true;
+    })
+    .catch((err) => {
+      console.error("[grody-github] Env filter init failed:", err);
+    });
+
+  return () => {
+    container.removeAttribute("data-filtering");
+  };
+});
+</script>
+
+{#if hint}
+  <p class="hint">{hint}</p>
+{/if}
+{#if loaded}
+  <div class="search">
+    <svg
+      aria-hidden="true"
+      height="16"
+      viewBox="0 0 16 16"
+      version="1.1"
+      width="16"
+      class="search-icon"
+    >
+      <path
+        fill-rule="evenodd"
+        d="M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z"
+      />
+    </svg>
+    <input
+      bind:this={inputEl}
+      type="search"
+      placeholder="Filter environments..."
+      aria-label="Filter environments"
+      form=""
+      bind:value={query}
+    >
+    {#if query}
+      <button type="button" aria-label="Clear filter" onclick={handleClear}>
+        <svg
+          aria-hidden="true"
+          height="16"
+          viewBox="0 0 16 16"
+          version="1.1"
+          width="16"
+        >
+          <path
+            fill-rule="evenodd"
+            d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z"
+          />
+        </svg>
+      </button>
+    {/if}
+  </div>
+  {#if filtering}
+    <ul class="results">
+      {#each filtered as env (env.name)}
+        <li>
+          <a
+            href={`/${owner}/${repo}/deployments/${encodeURIComponent(env.name)}`}
+          >
+            {env.name}
+          </a>
+        </li>
+      {:else}
+        <li class="empty"><em>No environments match your filter.</em></li>
+      {/each}
+    </ul>
+  {/if}
+{/if}
+
+<style>
+.hint {
+  margin: 0;
+  padding: 8px;
+  font-size: 12px;
+  color: var(--fgColor-muted);
+}
+
+.search {
+  position: relative;
+  padding: 8px;
+}
+
+.search-icon {
+  position: absolute;
+  top: 50%;
+  left: 16px;
+  transform: translateY(-50%);
+  fill: var(--fgColor-muted);
+  pointer-events: none;
+}
+
+input {
+  width: 100%;
+  padding: 5px 28px 5px 30px;
+  font-size: 14px;
+  color: var(--fgColor-default);
+  background-color: var(--bgColor-default);
+  border: 1px solid var(--borderColor-default);
+  border-radius: 6px;
+}
+
+input:focus {
+  outline: 2px solid var(--focus-outlineColor);
+  outline-offset: -1px;
+}
+
+button {
+  position: absolute;
+  top: 50%;
+  right: 12px;
+  transform: translateY(-50%);
+  padding: 2px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  fill: var(--fgColor-muted);
+}
+
+.results {
+  margin: 0;
+  padding: 0 8px 8px;
+  list-style: none;
+}
+
+.results a {
+  display: block;
+  padding: 6px 8px;
+  font-size: 14px;
+  color: var(--fgColor-default);
+  text-decoration: none;
+  border-radius: 6px;
+}
+
+.results a:hover {
+  background-color: var(--control-transparent-bgColor-hover);
+}
+
+.empty {
+  padding: 6px 8px;
+  font-size: 12px;
+  color: var(--fgColor-muted);
+}
+</style>

--- a/src/entrypoints/grody.content/features/env-filter/index.ts
+++ b/src/entrypoints/grody.content/features/env-filter/index.ts
@@ -1,0 +1,71 @@
+import { mount, unmount } from "svelte";
+import { waitForElement } from "@/lib/dom";
+import type { FeatureDefinition } from "@/lib/feature-types";
+import { isDeploymentsPage } from "../../page-context";
+import EnvFilter from "./EnvFilter.svelte";
+
+const ENV_NAV_SELECTOR = 'nav[class*="environmentlist"]';
+const CONTAINER_CLASS = "grody-env-filter";
+
+// Hides React's env list while our filter is active without touching its DOM
+const HIDE_RULE = `.${CONTAINER_CLASS}[data-filtering] ~ ${ENV_NAV_SELECTOR} { display: none; }`;
+
+function parseRepo(): { owner: string; repo: string } | null {
+  const [owner, repo] = location.pathname.split("/").filter(Boolean);
+  if (!owner || !repo) return null;
+  return { owner, repo };
+}
+
+function hasShowMoreControl(nav: HTMLElement): boolean {
+  return [...nav.querySelectorAll("a, button")].some((el) =>
+    /show more environments/i.test(el.textContent ?? ""),
+  );
+}
+
+const definition: FeatureDefinition = {
+  id: "env-filter",
+  include: [isDeploymentsPage],
+  reinitOnNavigation: true,
+  async init(_ctx, signal) {
+    const nav = await waitForElement<HTMLElement>(ENV_NAV_SELECTOR, signal);
+    if (!nav) {
+      if (import.meta.env.DEV && !signal.aborted) {
+        console.warn("[grody:env-filter] environments nav not found");
+      }
+      return;
+    }
+
+    if (!hasShowMoreControl(nav)) return;
+
+    const repoInfo = parseRepo();
+    if (!repoInfo) return;
+
+    const style = document.createElement("style");
+    style.textContent = HIDE_RULE;
+    document.head.append(style);
+
+    const container = document.createElement("div");
+    container.className = CONTAINER_CLASS;
+    nav.before(container);
+
+    let app: ReturnType<typeof mount> | null = mount(EnvFilter, {
+      target: container,
+      props: {
+        owner: repoInfo.owner,
+        repo: repoInfo.repo,
+        container,
+      },
+    });
+
+    signal.addEventListener("abort", () => {
+      if (app) {
+        unmount(app);
+        app = null;
+      }
+      container.remove();
+      style.remove();
+    });
+  },
+};
+
+export default definition;

--- a/src/entrypoints/grody.content/features/env-filter/index.ts
+++ b/src/entrypoints/grody.content/features/env-filter/index.ts
@@ -35,6 +35,8 @@ const definition: FeatureDefinition = {
       return;
     }
 
+    if (signal.aborted) return;
+
     if (!hasShowMoreControl(nav)) return;
 
     const repoInfo = parseRepo();

--- a/src/entrypoints/grody.content/features/env-filter/index.ts
+++ b/src/entrypoints/grody.content/features/env-filter/index.ts
@@ -50,14 +50,8 @@ const definition: FeatureDefinition = {
     container.className = CONTAINER_CLASS;
     nav.before(container);
 
-    let app: ReturnType<typeof mount> | null = mount(EnvFilter, {
-      target: container,
-      props: {
-        owner: repoInfo.owner,
-        repo: repoInfo.repo,
-        container,
-      },
-    });
+    // Registered before mount so a mount() throw still triggers cleanup
+    let app: ReturnType<typeof mount> | null = null;
 
     signal.addEventListener("abort", () => {
       if (app) {
@@ -66,6 +60,15 @@ const definition: FeatureDefinition = {
       }
       container.remove();
       style.remove();
+    });
+
+    app = mount(EnvFilter, {
+      target: container,
+      props: {
+        owner: repoInfo.owner,
+        repo: repoInfo.repo,
+        container,
+      },
     });
   },
 };

--- a/src/entrypoints/grody.content/features/workflow-filter/index.ts
+++ b/src/entrypoints/grody.content/features/workflow-filter/index.ts
@@ -51,14 +51,8 @@ const definition: FeatureDefinition = {
     const container = document.createElement("div");
     workflowsSection.before(container);
 
-    let app: ReturnType<typeof mount> | null = mount(WorkflowFilter, {
-      target: container,
-      props: {
-        owner: repoInfo.owner,
-        repo: repoInfo.repo,
-        navList,
-      },
-    });
+    // Registered before mount so a mount() throw still triggers cleanup
+    let app: ReturnType<typeof mount> | null = null;
 
     signal.addEventListener("abort", () => {
       if (app) {
@@ -66,6 +60,15 @@ const definition: FeatureDefinition = {
         app = null;
       }
       container.remove();
+    });
+
+    app = mount(WorkflowFilter, {
+      target: container,
+      props: {
+        owner: repoInfo.owner,
+        repo: repoInfo.repo,
+        navList,
+      },
     });
   },
 };

--- a/src/entrypoints/grody.content/features/workflow-filter/index.ts
+++ b/src/entrypoints/grody.content/features/workflow-filter/index.ts
@@ -31,6 +31,8 @@ const definition: FeatureDefinition = {
       return;
     }
 
+    if (signal.aborted) return;
+
     const showMore = navList
       .closest("nav")
       ?.querySelector<HTMLElement>(SHOW_MORE_SELECTOR);

--- a/src/entrypoints/grody.content/page-context.test.ts
+++ b/src/entrypoints/grody.content/page-context.test.ts
@@ -3,6 +3,7 @@ import type { PageContext } from "@/lib/feature-types";
 import {
   buildPageContext,
   isActionsPage,
+  isDeploymentsPage,
   isIssuePage,
   isPRPage,
   isRepoPage,
@@ -100,6 +101,30 @@ describe("isPRPage", () => {
 
   it("does not match pulls list", () => {
     expect(isPRPage(ctx("/owner/repo/pulls"))).toBe(false);
+  });
+});
+
+describe("isDeploymentsPage", () => {
+  it("matches /owner/repo/deployments", () => {
+    expect(isDeploymentsPage(ctx("/owner/repo/deployments"))).toBe(true);
+  });
+
+  it("matches /owner/repo/deployments/", () => {
+    expect(isDeploymentsPage(ctx("/owner/repo/deployments/"))).toBe(true);
+  });
+
+  it("matches environment subpages", () => {
+    expect(isDeploymentsPage(ctx("/owner/repo/deployments/prod-us"))).toBe(
+      true,
+    );
+  });
+
+  it("does not match /owner/repo/deploymentsx", () => {
+    expect(isDeploymentsPage(ctx("/owner/repo/deploymentsx"))).toBe(false);
+  });
+
+  it("does not match non-repo paths", () => {
+    expect(isDeploymentsPage(ctx("/deployments"))).toBe(false);
   });
 });
 

--- a/src/entrypoints/grody.content/page-context.ts
+++ b/src/entrypoints/grody.content/page-context.ts
@@ -15,6 +15,9 @@ export function buildPageContext(url: URL): PageContext {
 export const isActionsPage = (ctx: PageContext) =>
   /^\/[^/]+\/[^/]+\/actions(\/|$)/.test(ctx.pathname);
 
+export const isDeploymentsPage = (ctx: PageContext) =>
+  /^\/[^/]+\/[^/]+\/deployments(\/|$)/.test(ctx.pathname);
+
 export const isRepoPage = (ctx: PageContext) =>
   ctx.owner !== undefined && ctx.repo !== undefined;
 

--- a/src/lib/dom.test.ts
+++ b/src/lib/dom.test.ts
@@ -64,6 +64,14 @@ describe("waitForElement", () => {
     expect(el).toBeNull();
   });
 
+  it("returns null for an already-aborted signal even if element exists", async () => {
+    setBody('<div id="target">hello</div>');
+
+    const el = await waitForElement("#target", AbortSignal.abort("torn down"));
+
+    expect(el).toBeNull();
+  });
+
   it("disconnects observer after element is found", async () => {
     const promise = waitForElement("#target", AbortSignal.timeout(5000));
 

--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -6,10 +6,10 @@ export function waitForElement<T extends Element = Element>(
   selector: string,
   signal: AbortSignal,
 ): Promise<T | null> {
+  if (signal.aborted) return Promise.resolve(null);
+
   const existing = document.querySelector<T>(selector);
   if (existing) return Promise.resolve(existing);
-
-  if (signal.aborted) return Promise.resolve(null);
 
   return new Promise<T | null>((resolve) => {
     const observer = new MutationObserver(() => {

--- a/src/lib/github-api.test.ts
+++ b/src/lib/github-api.test.ts
@@ -1,12 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { fakeBrowser } from "wxt/testing/fake-browser";
 import {
+  fetchAllEnvironments,
   fetchAllWorkflows,
   GitHubApiError,
+  getEnvironments,
   getWorkflows,
   parseLinkHeader,
 } from "./github-api";
-import { workflowCache } from "./storage";
+import { environmentCache, workflowCache } from "./storage";
 
 describe("parseLinkHeader", () => {
   it("returns next URL from a valid Link header", () => {
@@ -386,6 +388,195 @@ describe("getWorkflows", () => {
     );
 
     const result = await getWorkflows("owner", "repo");
+    expect(result).toEqual({ ok: false, reason: "error" });
+  });
+});
+
+describe("fetchAllEnvironments", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("returns environment names", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce(
+        mockFetchResponse({
+          total_count: 2,
+          environments: [
+            { id: 1, name: "prod-us" },
+            { id: 2, name: "staging" },
+          ],
+        }),
+      ),
+    );
+
+    const result = await fetchAllEnvironments("owner", "repo", null);
+    expect(result).toEqual([{ name: "prod-us" }, { name: "staging" }]);
+  });
+
+  it("requests the environments endpoint with per_page=100", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        mockFetchResponse({ total_count: 0, environments: [] }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchAllEnvironments("owner", "repo", null);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "https://api.github.com/repos/owner/repo/environments?per_page=100",
+    );
+  });
+
+  it("follows pagination via Link headers", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        mockFetchResponse(
+          { total_count: 2, environments: [{ id: 1, name: "prod-us" }] },
+          {
+            linkHeader:
+              '<https://api.github.com/repos/owner/repo/environments?page=2&per_page=100>; rel="next"',
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        mockFetchResponse({
+          total_count: 2,
+          environments: [{ id: 2, name: "staging" }],
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchAllEnvironments("owner", "repo", null);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result).toHaveLength(2);
+  });
+
+  it("sends auth header when token provided", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        mockFetchResponse({ total_count: 0, environments: [] }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchAllEnvironments("owner", "repo", "ghp_test123");
+    const callHeaders = fetchMock.mock.calls[0]?.[1].headers;
+    expect(callHeaders.Authorization).toBe("token ghp_test123");
+  });
+
+  it("throws GitHubApiError on non-ok response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce(
+        mockFetchResponse(null, {
+          ok: false,
+          status: 403,
+          statusText: "Forbidden",
+        }),
+      ),
+    );
+
+    await expect(fetchAllEnvironments("owner", "repo", null)).rejects.toThrow(
+      GitHubApiError,
+    );
+  });
+});
+
+describe("getEnvironments", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  beforeEach(() => {
+    fakeBrowser.reset();
+  });
+
+  it("returns cached environments when cache is fresh", async () => {
+    const environments = [{ name: "prod-us" }];
+    await environmentCache.set("owner", "repo", environments);
+
+    const result = await getEnvironments("owner", "repo");
+    expect(result).toEqual({ ok: true, environments });
+  });
+
+  it("fetches from API when no cache, then caches result", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce(
+        mockFetchResponse({
+          total_count: 1,
+          environments: [{ id: 1, name: "prod-us" }],
+        }),
+      ),
+    );
+
+    const result = await getEnvironments("owner", "repo");
+    expect(result).toEqual({ ok: true, environments: [{ name: "prod-us" }] });
+
+    const cached = await environmentCache.get("owner", "repo");
+    expect(cached?.items).toEqual([{ name: "prod-us" }]);
+  });
+
+  it("returns rate-limited on 403", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce(
+        mockFetchResponse(null, {
+          ok: false,
+          status: 403,
+          statusText: "Forbidden",
+        }),
+      ),
+    );
+
+    const result = await getEnvironments("owner", "repo");
+    expect(result).toEqual({ ok: false, reason: "rate-limited" });
+  });
+
+  it("returns auth-required on 401", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce(
+        mockFetchResponse(null, {
+          ok: false,
+          status: 401,
+          statusText: "Unauthorized",
+        }),
+      ),
+    );
+
+    const result = await getEnvironments("owner", "repo");
+    expect(result).toEqual({ ok: false, reason: "auth-required" });
+  });
+
+  it("returns auth-required on 404", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce(
+        mockFetchResponse(null, {
+          ok: false,
+          status: 404,
+          statusText: "Not Found",
+        }),
+      ),
+    );
+
+    const result = await getEnvironments("owner", "repo");
+    expect(result).toEqual({ ok: false, reason: "auth-required" });
+  });
+
+  it("returns generic error on unexpected failures", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValueOnce(new Error("Network failure")),
+    );
+
+    const result = await getEnvironments("owner", "repo");
     expect(result).toEqual({ ok: false, reason: "error" });
   });
 });

--- a/src/lib/github-api.test.ts
+++ b/src/lib/github-api.test.ts
@@ -6,7 +6,7 @@ import {
   getWorkflows,
   parseLinkHeader,
 } from "./github-api";
-import { setCachedWorkflows } from "./storage";
+import { workflowCache } from "./storage";
 
 describe("parseLinkHeader", () => {
   it("returns next URL from a valid Link header", () => {
@@ -273,7 +273,7 @@ describe("getWorkflows", () => {
 
   it("returns cached workflows when cache is fresh", async () => {
     const workflows = [{ name: "CI", path: ".github/workflows/ci.yml" }];
-    await setCachedWorkflows("owner", "repo", workflows);
+    await workflowCache.set("owner", "repo", workflows);
 
     const result = await getWorkflows("owner", "repo");
     expect(result).toEqual({ ok: true, workflows });

--- a/src/lib/github-api.ts
+++ b/src/lib/github-api.ts
@@ -1,6 +1,11 @@
-import type { GetWorkflowsMessage } from "./messages";
-import { tokenStorage, workflowCache } from "./storage";
-import type { Workflow, WorkflowResult } from "./types";
+import type { GetEnvironmentsMessage, GetWorkflowsMessage } from "./messages";
+import { environmentCache, tokenStorage, workflowCache } from "./storage";
+import type {
+  Environment,
+  EnvironmentResult,
+  Workflow,
+  WorkflowResult,
+} from "./types";
 
 type WorkflowApiResponse = {
   total_count: number;
@@ -103,5 +108,88 @@ export async function requestWorkflows(
   repo: string,
 ): Promise<WorkflowResult> {
   const message: GetWorkflowsMessage = { type: "GET_WORKFLOWS", owner, repo };
+  return browser.runtime.sendMessage(message);
+}
+
+type EnvironmentApiResponse = {
+  total_count: number;
+  environments: Array<{
+    id: number;
+    name: string;
+  }>;
+};
+
+export async function fetchAllEnvironments(
+  owner: string,
+  repo: string,
+  token: string | null,
+): Promise<Environment[]> {
+  const environments: Environment[] = [];
+  let url: string | null =
+    `https://api.github.com/repos/${owner}/${repo}/environments?per_page=100`;
+  let page = 0;
+
+  while (url && page < MAX_PAGES) {
+    page++;
+    const headers: Record<string, string> = {
+      Accept: "application/vnd.github.v3+json",
+    };
+    if (token) {
+      headers.Authorization = `token ${token}`;
+    }
+    const response = await fetch(url, { headers });
+
+    if (!response.ok) {
+      throw new GitHubApiError(response.status, response.statusText);
+    }
+
+    const data: EnvironmentApiResponse = await response.json();
+
+    for (const environment of data.environments) {
+      environments.push({ name: environment.name });
+    }
+
+    url = parseLinkHeader(response.headers.get("Link"));
+  }
+
+  return environments;
+}
+
+export async function getEnvironments(
+  owner: string,
+  repo: string,
+): Promise<EnvironmentResult> {
+  try {
+    const token = (await tokenStorage.getValue()) || null;
+
+    const cached = await environmentCache.get(owner, repo);
+    if (cached) return { ok: true, environments: cached.items };
+
+    const environments = await fetchAllEnvironments(owner, repo, token);
+    await environmentCache.set(owner, repo, environments);
+    return { ok: true, environments };
+  } catch (err) {
+    console.error("[grody-github] Failed to fetch environments:", err);
+
+    if (err instanceof GitHubApiError) {
+      if (err.status === 403) return { ok: false, reason: "rate-limited" };
+      if (err.status === 401 || err.status === 404) {
+        return { ok: false, reason: "auth-required" };
+      }
+    }
+
+    return { ok: false, reason: "error" };
+  }
+}
+
+export async function requestEnvironments(
+  owner: string,
+  repo: string,
+): Promise<EnvironmentResult> {
+  const message: GetEnvironmentsMessage = {
+    type: "GET_ENVIRONMENTS",
+    owner,
+    repo,
+  };
   return browser.runtime.sendMessage(message);
 }

--- a/src/lib/github-api.ts
+++ b/src/lib/github-api.ts
@@ -1,9 +1,5 @@
 import type { GetWorkflowsMessage } from "./messages";
-import {
-  getCachedWorkflows,
-  setCachedWorkflows,
-  tokenStorage,
-} from "./storage";
+import { tokenStorage, workflowCache } from "./storage";
 import type { Workflow, WorkflowResult } from "./types";
 
 type WorkflowApiResponse = {
@@ -82,11 +78,11 @@ export async function getWorkflows(
   try {
     const token = (await tokenStorage.getValue()) || null;
 
-    const cached = await getCachedWorkflows(owner, repo);
-    if (cached) return { ok: true, workflows: cached.workflows };
+    const cached = await workflowCache.get(owner, repo);
+    if (cached) return { ok: true, workflows: cached.items };
 
     const workflows = await fetchAllWorkflows(owner, repo, token);
-    await setCachedWorkflows(owner, repo, workflows);
+    await workflowCache.set(owner, repo, workflows);
     return { ok: true, workflows };
   } catch (err) {
     console.error("[grody-github] Failed to fetch workflows:", err);

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -1,4 +1,4 @@
-import type { WorkflowResult } from "./types";
+import type { EnvironmentResult, WorkflowResult } from "./types";
 
 export type GetWorkflowsMessage = {
   type: "GET_WORKFLOWS";
@@ -6,8 +6,15 @@ export type GetWorkflowsMessage = {
   repo: string;
 };
 
-export type ExtensionMessage = GetWorkflowsMessage;
+export type GetEnvironmentsMessage = {
+  type: "GET_ENVIRONMENTS";
+  owner: string;
+  repo: string;
+};
+
+export type ExtensionMessage = GetWorkflowsMessage | GetEnvironmentsMessage;
 
 export type MessageResponseMap = {
   GET_WORKFLOWS: WorkflowResult;
+  GET_ENVIRONMENTS: EnvironmentResult;
 };

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -1,58 +1,76 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fakeBrowser } from "wxt/testing/fake-browser";
-import { cacheKey, getCachedWorkflows, setCachedWorkflows } from "./storage";
+import { environmentCache, workflowCache } from "./storage";
 
-describe("cacheKey", () => {
-  it("generates correct key format", () => {
-    expect(cacheKey("owner", "repo")).toBe("local:workflow-cache:owner/repo");
+describe("cache keys", () => {
+  it("workflowCache keeps the legacy key prefix", () => {
+    expect(workflowCache.key("owner", "repo")).toBe(
+      "local:workflow-cache:owner/repo",
+    );
+  });
+
+  it("environmentCache uses the env-cache prefix", () => {
+    expect(environmentCache.key("owner", "repo")).toBe(
+      "local:env-cache:owner/repo",
+    );
   });
 });
 
-describe("getCachedWorkflows", () => {
+describe("createListCache get/set", () => {
   beforeEach(() => {
     fakeBrowser.reset();
     vi.restoreAllMocks();
   });
 
-  it("returns cached data when within TTL", async () => {
+  it("returns cached items when within TTL", async () => {
     const workflows = [{ name: "CI", path: ".github/workflows/ci.yml" }];
-    await setCachedWorkflows("owner", "repo", workflows);
+    await workflowCache.set("owner", "repo", workflows);
 
-    const result = await getCachedWorkflows("owner", "repo");
-    expect(result).not.toBeNull();
-    expect(result?.workflows).toEqual(workflows);
+    const result = await workflowCache.get("owner", "repo");
+    expect(result?.items).toEqual(workflows);
   });
 
   it("returns null when cache is expired", async () => {
-    const workflows = [{ name: "CI", path: ".github/workflows/ci.yml" }];
-    await setCachedWorkflows("owner", "repo", workflows);
+    await workflowCache.set("owner", "repo", [
+      { name: "CI", path: ".github/workflows/ci.yml" },
+    ]);
 
     const dayPlusOne = Date.now() + 25 * 60 * 60 * 1000;
     vi.spyOn(Date, "now").mockReturnValue(dayPlusOne);
 
-    const result = await getCachedWorkflows("owner", "repo");
-    expect(result).toBeNull();
+    expect(await workflowCache.get("owner", "repo")).toBeNull();
   });
 
   it("returns null when no cache exists", async () => {
-    const result = await getCachedWorkflows("owner", "repo");
-    expect(result).toBeNull();
-  });
-});
-
-describe("setCachedWorkflows", () => {
-  beforeEach(() => {
-    fakeBrowser.reset();
+    expect(await workflowCache.get("owner", "repo")).toBeNull();
   });
 
-  it("stores workflows with current timestamp", async () => {
+  it("treats pre-generic cache shapes as a miss", async () => {
+    // Old workflow cache entries stored { workflows, timestamp }
+    await storage.setItem(workflowCache.key("owner", "repo"), {
+      workflows: [{ name: "CI", path: ".github/workflows/ci.yml" }],
+      timestamp: Date.now(),
+    });
+
+    expect(await workflowCache.get("owner", "repo")).toBeNull();
+  });
+
+  it("stores items with current timestamp", async () => {
     const now = 1700000000000;
     vi.spyOn(Date, "now").mockReturnValue(now);
 
-    const workflows = [{ name: "CI", path: ".github/workflows/ci.yml" }];
-    await setCachedWorkflows("owner", "repo", workflows);
+    const envs = [{ name: "prod-us" }];
+    await environmentCache.set("owner", "repo", envs);
 
-    const result = await getCachedWorkflows("owner", "repo");
-    expect(result).toEqual({ workflows, timestamp: now });
+    const result = await environmentCache.get("owner", "repo");
+    expect(result).toEqual({ items: envs, timestamp: now });
+  });
+
+  it("keeps caches with different prefixes independent", async () => {
+    await workflowCache.set("owner", "repo", [
+      { name: "CI", path: ".github/workflows/ci.yml" },
+    ]);
+
+    expect(await environmentCache.get("owner", "repo")).toBeNull();
   });
 });

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,4 +1,4 @@
-import type { WorkflowCache } from "./types";
+import type { Environment, ListCacheEntry, Workflow } from "./types";
 
 export const tokenStorage = storage.defineItem<string>("local:github-pat", {
   fallback: "",
@@ -6,27 +6,27 @@ export const tokenStorage = storage.defineItem<string>("local:github-pat", {
 
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 
-export function cacheKey(owner: string, repo: string) {
-  return `local:workflow-cache:${owner}/${repo}` as `local:${string}`;
+export function createListCache<T>(prefix: string) {
+  const key = (owner: string, repo: string) =>
+    `local:${prefix}:${owner}/${repo}` as `local:${string}`;
+
+  return {
+    key,
+    async get(owner: string, repo: string): Promise<ListCacheEntry<T> | null> {
+      const cached = await storage.getItem<ListCacheEntry<T>>(key(owner, repo));
+      // Array guard also invalidates entries written in the pre-generic shape
+      if (!cached || !Array.isArray(cached.items)) return null;
+      if (Date.now() - cached.timestamp > CACHE_TTL_MS) return null;
+      return cached;
+    },
+    async set(owner: string, repo: string, items: T[]): Promise<void> {
+      await storage.setItem<ListCacheEntry<T>>(key(owner, repo), {
+        items,
+        timestamp: Date.now(),
+      });
+    },
+  };
 }
 
-export async function getCachedWorkflows(
-  owner: string,
-  repo: string,
-): Promise<WorkflowCache | null> {
-  const cached = await storage.getItem<WorkflowCache>(cacheKey(owner, repo));
-  if (!cached) return null;
-  if (Date.now() - cached.timestamp > CACHE_TTL_MS) return null;
-  return cached;
-}
-
-export async function setCachedWorkflows(
-  owner: string,
-  repo: string,
-  workflows: WorkflowCache["workflows"],
-): Promise<void> {
-  await storage.setItem<WorkflowCache>(cacheKey(owner, repo), {
-    workflows,
-    timestamp: Date.now(),
-  });
-}
+export const workflowCache = createListCache<Workflow>("workflow-cache");
+export const environmentCache = createListCache<Environment>("env-cache");

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -3,11 +3,19 @@ export type Workflow = {
   path: string;
 };
 
-export type WorkflowCache = {
-  workflows: Workflow[];
+export type WorkflowResult =
+  | { ok: true; workflows: Workflow[] }
+  | { ok: false; reason: "rate-limited" | "auth-required" | "error" };
+
+export type Environment = {
+  name: string;
+};
+
+export type ListCacheEntry<T> = {
+  items: T[];
   timestamp: number;
 };
 
-export type WorkflowResult =
-  | { ok: true; workflows: Workflow[] }
+export type EnvironmentResult =
+  | { ok: true; environments: Environment[] }
   | { ok: false; reason: "rate-limited" | "auth-required" | "error" };


### PR DESCRIPTION
# Context

Repos with 100+ deployment environments (hi, monorepo) make the deployments sidebar useless — 50 envs render, the rest hide behind "Show more environments", and finding one means scrolling and paging. We already solved this exact problem for the Actions workflow sidebar, so this ports the same idea over.

The catch: the deployments page is one of GitHub's React apps (Primer React, hashed CSS-module classes), so workflow-filter's DOM-swap approach doesn't port. React owns that subtree — mutating it risks getting clobbered on re-render. Instead, the filter renders its own results in a sibling container and hides React's list with a stylesheet rule keyed off a `data-filtering` attribute on *our* element. React never sees a change to anything it owns.

Data flow is a clone of the workflows pipeline: content script → `GET_ENVIRONMENTS` background message → REST `/repos/{o}/{r}/environments` (paginated, 24h cache). Fine-grained PATs need no new scopes — Actions (read) covers the environments endpoint too (verified against GitHub's docs).

# Changes Made

- `features/env-filter/` — new feature module: mount gate (only when "Show more environments" exists), `EnvFilter.svelte` with search input + overlay results, scoped styles on GitHub css vars (theme-safe)
- `storage.ts` — workflow-specific cache helpers generalized into `createListCache<T>`; `workflowCache` keeps its legacy key prefix, `environmentCache` added; array guard treats pre-refactor cache shapes as a miss (one refetch, no migration code)
- `github-api.ts` — `fetchAllEnvironments` / `getEnvironments` / `requestEnvironments`, same pagination + 403/401/404 reason mapping as workflows
- `messages.ts` / `background.ts` — `GET_ENVIRONMENTS` round-trip
- `page-context.ts` — `isDeploymentsPage` predicate
- README — feature section, tagline, dev commands accuracy fix
- CLAUDE.md — gotchas on React-owned DOM + hashed css-module selectors

# Testing Notes

- 111/111 vitest (16 new: env fetch/pagination/error mapping, generic cache TTL + old-shape invalidation, predicate)
- `pnpm lint`, `pnpm check`, `pnpm build` all clean
- manual pass on the live extension against LimbleCMMS/monorepo (100+ envs): filtering matches envs beyond the "show more" cutoff, clear restores React's list with pins/active state intact, filtered links navigate correctly, input re-mounts across client-side route changes, empty state renders
- no-truncation case verified on vercel/next.js (10 envs): no input rendered
- dark theme verified live; light uses the same GitHub css vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Environment Sidebar Filter to deployment pages.
  * Search environments in real time using multiple terms.
  * Open matching deployment pages directly from search results.
  * Filter appears when the environment list is truncated and supports clearing/refocusing.
  * Environment data is cached for up to 24 hours.

* **Bug Fixes**
  * Added clearer authentication, rate-limit, and loading-failure guidance.

* **Documentation**
  * Updated setup and usage documentation for deployment environment filtering.
  * Replaced the formatting command with the lint-and-fix command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->