### PR TITLE
chore(renovate): update wxt group and gate on minors

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,6 @@
   "schedule": ["after 4pm", "before 8am"],
   "prConcurrentLimit": 5,
   "prHourlyLimit": 0,
-  "separateMajorMinor": true,
   "major": {
     "dependencyDashboardApproval": true
   },
@@ -22,15 +21,31 @@
   },
   "packageRules": [
     {
-      "description": "Group extension framework (WXT + Svelte share peer deps)",
+      "description": "Group extension framework (WXT + Svelte share peer deps; vite and web-ext are wxt peer deps)",
       "matchPackageNames": [
         "wxt",
         "@wxt-dev/**",
         "svelte",
         "svelte-check",
-        "@tsconfig/svelte"
+        "@tsconfig/svelte",
+        "vite",
+        "web-ext"
       ],
       "groupName": "extension framework"
+    },
+    {
+      "description": "wxt is 0.x so minor bumps are breaking - gate the group's minors behind dashboard approval like majors",
+      "matchPackageNames": [
+        "wxt",
+        "@wxt-dev/**",
+        "svelte",
+        "svelte-check",
+        "@tsconfig/svelte",
+        "vite",
+        "web-ext"
+      ],
+      "matchUpdateTypes": ["minor"],
+      "dependencyDashboardApproval": true
     },
     {
       "description": "Group TypeScript ecosystem",


### PR DESCRIPTION
# Summary

Reconfigure renovate after the minor bump to `wxt` changed how deps need to be installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update grouping for extension framework packages.
  * Added approval requirements for minor updates in the grouped dependency set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->